### PR TITLE
Error Display, Clipboard Copy, and Exit Status

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "arboard",
         "crossterm",
         "ratatui",
         "rustfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ run_script = "0.10.1"
 tui-textarea = "0.4.0"
 fuzzy-matcher = "0.3.7"
 dirs = "5.0.1"
+arboard = "3.4.0"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Chopsticks 
+
+Chopsticks is a command-line snippet management tool written in Rust, inspired by [pet](https://github.com/knqyf263/pet).
+
+## Description
+
+Chopsticks is a tool designed to help manage code snippets from the command line. It provides functionalities for adding, removing, editing, saving, and executing snippets efficiently.
+
+## Getting Started
+
+### Installing
+To install Chopsticks, you can use Cargo, Rust's package manager, by running the following command:
+
+```sh
+cargo install --git https://github.com/cuckoio/chopsticks.git
+```
+
+### Suggestion
+Due to the long name "chopsticks", it's recommended to create an alias for easier access.
+
+
+### Keymap
+
+Keymap for Chopsticks:
+
+- `<Enter>` Execute command
+- `Ctrl` + `<a>` Add new snippet
+- `Ctrl` + `<r>` Remove snippet
+- `Ctrl` + `<e>` Edit snippet 
+- `Ctrl` + `<s>` Save snippet when editing
+- `Ctrl` + `<c>` Quit chopsticks or cancel when editing
+- `Ctrl` + `<Enter>` Copy to your clipboard
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,9 @@ async fn main() -> Result<()> {
         }
     }
 
-    tui::restore_terminal()?;
+    if !app.terminal_restored {
+        tui::restore_terminal()?;
+    }
 
     Ok(())
 }

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -31,6 +31,7 @@ pub struct App<'a> {
     pub quit: bool,
     pub terminal_restored: bool,
     pub(super) is_editing: bool,
+    pub(super) error_msg: Option<String>,
     pub(super) search_bar: TextArea<'a>,
     pub(super) editor: Option<TextArea<'a>>,
     pub(super) snippets: Vec<Snippet>,
@@ -50,6 +51,7 @@ impl<'a> App<'a> {
             quit: false,
             terminal_restored: false,
             is_editing: false,
+            error_msg: None,
             search_bar: TextArea::default(),
             editor: None,
             snippets: Vec::new(),
@@ -63,12 +65,13 @@ impl<'a> App<'a> {
         self.state.select(Some(0));
     }
 
-    pub fn quit(&mut self) {
+    pub fn quit(&mut self) -> Result<()> {
         let snippets =
             toml::to_string_pretty(&HashMap::from([("snippets", &self.snippets)])).unwrap();
         let snippet_path = Self::snippet_path();
         fs::write(snippet_path, snippets).unwrap();
         self.quit = true;
+        Ok(())
     }
 
     fn load_snippets(&mut self) -> Result<Vec<Snippet>> {

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{collections::HashMap, fmt::Display, fs, path::PathBuf};
 
 use anyhow::Result;
 use ratatui::widgets::ListState;
@@ -14,10 +14,11 @@ pub struct Snippet {
     pub description: String,
 }
 
-impl ToString for Snippet {
+impl Display for Snippet {
     #[rustfmt::skip]
-    fn to_string(&self) -> String {
-        format!(
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
             "priority = {}\ncmd = \'\'\'{}\'\'\'\ndescription = \'\'\'{}\'\'\'",
             self.priority,
             if self.cmd.is_empty() { "\n" } else { self.cmd.as_str() },

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -30,7 +30,7 @@ impl ToString for Snippet {
 pub struct App<'a> {
     pub quit: bool,
     pub terminal_restored: bool,
-    pub(super) editing: bool,
+    pub(super) is_editing: bool,
     pub(super) search_bar: TextArea<'a>,
     pub(super) editor: Option<TextArea<'a>>,
     pub(super) snippets: Vec<Snippet>,
@@ -49,7 +49,7 @@ impl<'a> App<'a> {
         Self {
             quit: false,
             terminal_restored: false,
-            editing: false,
+            is_editing: false,
             search_bar: TextArea::default(),
             editor: None,
             snippets: Vec::new(),

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -29,6 +29,7 @@ impl ToString for Snippet {
 #[derive(Debug)]
 pub struct App<'a> {
     pub quit: bool,
+    pub terminal_restored: bool,
     pub(super) editing: bool,
     pub(super) search_bar: TextArea<'a>,
     pub(super) editor: Option<TextArea<'a>>,
@@ -47,6 +48,7 @@ impl<'a> App<'a> {
     pub fn new() -> App<'a> {
         Self {
             quit: false,
+            terminal_restored: false,
             editing: false,
             search_bar: TextArea::default(),
             editor: None,

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -37,16 +37,16 @@ impl<'a> App<'a> {
                 self.quit()
             }
             Msg::Edit(EditMsg::Open { snippet }) => {
-                self.editing = true;
+                self.is_editing = true;
                 self.editor = Some(snippet.to_string().lines().collect());
             }
             Msg::Edit(EditMsg::Save) => {
                 self.save_snippet();
-                self.editing = false;
+                self.is_editing = false;
                 self.editor = None;
             }
             Msg::Edit(EditMsg::Cancel) => {
-                self.editing = false;
+                self.is_editing = false;
                 self.editor = None;
             }
             Msg::CopyToClipboard => self.copy_to_clipboard(),
@@ -57,7 +57,7 @@ impl<'a> App<'a> {
     pub async fn handle_event(&mut self) -> Option<Msg> {
         match self.events.next().await? {
             Event::Key(key_evt) => {
-                if self.editing {
+                if self.is_editing {
                     self.handle_edit_event(key_evt)
                 } else {
                     match (key_evt.code, key_evt.modifiers) {

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -199,7 +199,6 @@ impl<'a> App<'a> {
             let mut priority = 0i64;
             self.search_bar.lines()[0]
                 .split_ascii_whitespace()
-                .into_iter()
                 .for_each(|k| {
                     priority += matcher.fuzzy_match(&s.cmd, k).unwrap_or_default();
                     priority += matcher.fuzzy_match(&s.description, k).unwrap_or_default();

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -13,6 +13,7 @@ pub enum Msg {
     AppClose,
     SelectNext,
     SelectPrev,
+    SearchCmd,
     ExecuteCmd,
     CopyToClipboard,
     RemoveSnippet,
@@ -28,29 +29,32 @@ pub enum EditMsg {
 
 impl<'a> App<'a> {
     pub fn update(&mut self, msg: Msg) {
-        match msg {
+        if let Err(err) = match msg {
             Msg::SelectNext => self.select_next(),
             Msg::SelectPrev => self.select_previous(),
             Msg::RemoveSnippet => self.remove_snippet(),
-            Msg::ExecuteCmd => {
-                self.execute_cmd().unwrap();
-                self.quit()
-            }
+            Msg::SearchCmd => self.search_snippet(),
+            Msg::ExecuteCmd => self.execute_cmd().and_then(|_| self.quit()),
             Msg::Edit(EditMsg::Open { snippet }) => {
                 self.is_editing = true;
                 self.editor = Some(snippet.to_string().lines().collect());
+                Ok(())
             }
             Msg::Edit(EditMsg::Save) => {
-                self.save_snippet();
+                let result = self.save_snippet();
                 self.is_editing = false;
                 self.editor = None;
+                result
             }
             Msg::Edit(EditMsg::Cancel) => {
                 self.is_editing = false;
                 self.editor = None;
+                Ok(())
             }
             Msg::CopyToClipboard => self.copy_to_clipboard(),
             Msg::AppClose => self.quit(),
+        } {
+            self.error_msg = Some(err.to_string());
         }
     }
 
@@ -101,8 +105,7 @@ impl<'a> App<'a> {
 
             _ => {
                 self.search_bar.input(evt);
-                self.search_snippet();
-                None
+                Some(Msg::SearchCmd)
             }
         }
     }
@@ -130,7 +133,7 @@ impl<'a> App<'a> {
         }
     }
 
-    fn select_next(&mut self) {
+    fn select_next(&mut self) -> Result<()> {
         // This won't panic because 'selected' is initialized to 0 from the beginning.
         let i = self.state.selected().unwrap();
         let i = if i >= self.snippets.len().saturating_sub(1) {
@@ -140,9 +143,10 @@ impl<'a> App<'a> {
         };
 
         self.state.select(Some(i));
+        Ok(())
     }
 
-    fn select_previous(&mut self) {
+    fn select_previous(&mut self) -> Result<()> {
         // This won't panic because 'selected' is initialized to 0 from the beginning.
         let i = self.state.selected().unwrap();
         let i = if i == 0 {
@@ -151,6 +155,7 @@ impl<'a> App<'a> {
             i - 1
         };
         self.state.select(Some(i));
+        Ok(())
     }
 
     fn execute_cmd(&mut self) -> Result<()> {
@@ -176,16 +181,18 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    fn copy_to_clipboard(&self) {
-        let mut clipboard = Clipboard::new().expect("Failed to construct new clipboard instance.");
+    fn copy_to_clipboard(&self) -> Result<()> {
+        let mut clipboard = Clipboard::new()?;
 
         let index = self.state.selected().unwrap();
         if let Some(snippet) = self.snippets.get(index) {
-            clipboard.set_text(snippet.cmd.as_str()).unwrap();
+            clipboard.set_text(snippet.cmd.as_str())?;
         }
+
+        Ok(())
     }
 
-    fn search_snippet(&mut self) {
+    fn search_snippet(&mut self) -> Result<()> {
         let matcher = SkimMatcherV2::default();
 
         self.snippets.iter_mut().for_each(|s| {
@@ -202,19 +209,23 @@ impl<'a> App<'a> {
 
         self.snippets.sort_by(|a, b| b.priority.cmp(&a.priority));
         self.state.select(Some(0));
+
+        Ok(())
     }
 
-    fn save_snippet(&mut self) {
-        // TODO: popup err msg
+    fn save_snippet(&mut self) -> Result<()> {
         let snippet = self.editor.as_ref().unwrap().lines().join("\n");
-        let snippet: Snippet = toml::from_str(&snippet).unwrap();
+        let snippet: Snippet = toml::from_str(&snippet)?;
         self.snippets.push(snippet);
+        Ok(())
     }
 
-    fn remove_snippet(&mut self) {
+    fn remove_snippet(&mut self) -> Result<()> {
         let index = self.state.selected().unwrap();
         if index < self.snippets.len() {
             self.snippets.remove(index);
         }
+
+        Ok(())
     }
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -1,7 +1,7 @@
 use super::model::App;
 use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, HighlightSpacing, List, ListItem, Padding, Paragraph, Wrap},
     Frame,
@@ -29,7 +29,11 @@ impl<'a> App<'a> {
             self.view_snippet_details(frame, chunks[1]);
         }
 
-        self.view_instructions(frame, chunks[1]);
+        if self.error_msg.is_some() {
+            self.view_error_msg(frame, chunks[1]);
+        } else {
+            self.view_instructions(frame, chunks[1]);
+        }
     }
 
     fn view_search_bar(&mut self, frame: &mut Frame, rect: Rect) {
@@ -124,27 +128,35 @@ impl<'a> App<'a> {
     }
 
     fn view_instructions(&mut self, frame: &mut Frame, rect: Rect) {
-        let inner = Block::new().inner(rect);
+        let inner = Block::new().padding(Padding::horizontal(1)).inner(rect);
         let instructions = Line::from(vec![
-            Span::from("<Enter> Execute").bold().bg(Color::Cyan),
+            Span::from("<Enter> Execute").bold().on_cyan(),
             Span::from(" | "),
-            Span::from("Ctrl").bold().bg(Color::Cyan),
+            Span::from("Ctrl").bold().on_cyan(),
             Span::from(" + "),
-            Span::from("<a> Add").bg(Color::DarkGray),
+            Span::from("<a> Add").on_dark_gray(),
             Span::from(" "),
-            Span::from("<r> Remove").bg(Color::DarkGray),
+            Span::from("<r> Remove").on_dark_gray(),
             Span::from(" "),
-            Span::from("<e> Edit").bg(Color::DarkGray),
+            Span::from("<e> Edit").on_dark_gray(),
             Span::from(" "),
-            Span::from("<s> Save").bg(Color::DarkGray),
+            Span::from("<s> Save").on_dark_gray(),
             Span::from(" "),
-            Span::from("<c> quit or cancel").bg(Color::DarkGray),
+            Span::from("<c> quit or cancel").on_dark_gray(),
             Span::from(" "),
-            Span::from("<enter> copy").bg(Color::DarkGray),
+            Span::from("<enter> copy").on_dark_gray(),
         ])
-        .fg(Color::White)
+        .white()
         .alignment(Alignment::Left);
 
         frame.render_widget(instructions, inner);
+    }
+
+    fn view_error_msg(&self, frame: &mut Frame, rect: Rect) {
+        let inner = Block::new().padding(Padding::horizontal(1)).inner(rect);
+        let msg = self.error_msg.as_ref().unwrap();
+        let content = Line::from(msg.as_str()).red();
+
+        frame.render_widget(content, inner);
     }
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -139,6 +139,8 @@ impl<'a> App<'a> {
             Span::from("<s> Save").bg(Color::DarkGray),
             Span::from(" "),
             Span::from("<c> quit or cancel").bg(Color::DarkGray),
+            Span::from(" "),
+            Span::from("<enter> copy").bg(Color::DarkGray),
         ])
         .fg(Color::White)
         .alignment(Alignment::Left);

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -12,7 +12,9 @@ impl<'a> App<'a> {
         let chunks =
             Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(frame.size());
 
-        if !self.editing {
+        if self.is_editing {
+            self.view_editor(frame, frame.size());
+        } else {
             let chunks =
                 Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .split(chunks[0]);
@@ -20,13 +22,11 @@ impl<'a> App<'a> {
             {
                 let chunks =
                     Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).split(chunks[0]);
-
                 self.view_search_bar(frame, chunks[0]);
                 self.view_snippets_list(frame, chunks[1]);
             }
+
             self.view_snippet_details(frame, chunks[1]);
-        } else {
-            self.view_editor(frame, frame.size());
         }
 
         self.view_instructions(frame, chunks[1]);


### PR DESCRIPTION
- Error Display: Error messages now appear at the bottom.

- Clipboard Copy: Added 'copy' command support for easy command copying.

- Exit Status Output: Provides clear exit status codes.

- Refactoring and Docs: Renamed 'editing' to 'is_editing' and updated README.md. Clippy lint warning addressed.